### PR TITLE
Fixed typo in bottom limit question

### DIFF
--- a/whatIsALimit/exercises/limitFromGraph1.tex
+++ b/whatIsALimit/exercises/limitFromGraph1.tex
@@ -87,7 +87,7 @@ Find the following limits, if they exist.  If a limit does not exist, explain wh
 \noindent\rule[0.5ex]{\linewidth}{.2pt}
 
 \[
-\lim_{x\to3^+}f(x) = \answer{DNE}
+\lim_{x\to3}f(x) = \answer{DNE}
 \]
 \begin{multipleChoice}
 \choice{The limit does exist.}


### PR DESCRIPTION
It still asked for \lim_{x\to3^+} instead of \lim_{x\to3}