### PR TITLE
Fix formating errors

### DIFF
--- a/exams/calculus3/exam2/lagrangeMultipliers3.tex
+++ b/exams/calculus3/exam2/lagrangeMultipliers3.tex
@@ -30,7 +30,7 @@ Consequently,
 \begin{align*}
   3x &= \lambda \cdot \frac{9}{2}, \\
   2y &= \lambda \cdot 2, \\
-  z &= \lambda \cdot frac{1}{2}, \\
+  z &= \lambda \cdot \frac{1}{2}, \\
   1 &= 3x + 2y + z,
 \end{align*}
 \end{hint}
@@ -38,7 +38,7 @@ Consequently,
 And so
 \begin{align*}
 1
-&= \lambda \cdot \frac{9}{2} + \lambda \cdot 2 + \lambda \cdot frac{1}{2} \\
+&= \lambda \cdot \frac{9}{2} + \lambda \cdot 2 + \lambda \cdot \frac{1}{2} \\
 &= \lambda \cdot \left( \frac{9}{2} + 2 + \frac{1}{2} \right) \\
 &= \lambda \cdot \left( \frac{9}{2} + 2 + \frac{1}{2} \right) \\
 &= 7 \lambda


### PR DESCRIPTION
Missing \ caused \frac{1}{2} to render as frac12 in the hint.