### PR TITLE
Update diginWhatIsALimit.tex

### DIFF
--- a/whatIsALimit/digInWhatIsALimit.tex
+++ b/whatIsALimit/digInWhatIsALimit.tex
@@ -256,7 +256,7 @@ limit does not exists.
 Tables can be used to help guess limits, but one must be careful.
 
 \begin{question}
-  Consider $f(x) = \sin\left(\frac{\pi}{x}\right)$. Fill in the tables
+  Consider $f(x) = \sin\left(\frac{x}{\pi}\right)$. Fill in the tables
   below rounding to three decimal places:
   \[
   \begin{array}{l|l}
@@ -269,7 +269,7 @@ Tables can be used to help guess limits, but one must be careful.
     \]
   We may rush and say that, based on the table above,
    \[
-  \lim_{x\to 0}\sin\left(\frac{\pi}{x}\right)=0.
+  \lim_{x\to 0}\sin\left(\frac{x}{\pi}\right)=0.
   \]
   But, recall the definition of the limit: $L$ is the limit if the value of $f(x)$ is as close as one wishes to $L$ for
   \textbf{all} $x$ sufficiently close, but not equal to, $a$. 
@@ -289,13 +289,13 @@ But, wait! Fill in another table.
   \]
   What do these two tables tell us about
   \[
-  \lim_{x\to 0}\sin\left(\frac{\pi}{x}\right)?
+  \lim_{x\to 0}\sin\left(\frac{x}{\pi}\right)?
   \]
   \begin{multipleChoice}
-    \choice{$\lim_{x\to 0}\sin\left(\frac{\pi}{x}\right) = 0$}
-    \choice{$\lim_{x\to 0}\sin\left(\frac{\pi}{x}\right)=1$}
-    \choice{$\lim_{x\to 0}\sin\left(\frac{\pi}{x}\right) = -.866$}
-    \choice{$\lim_{x\to 0}\sin\left(\frac{\pi}{x}\right) = -.433$}
+    \choice{$\lim_{x\to 0}\sin\left(\frac{x}{\pi}\right) = 0$}
+    \choice{$\lim_{x\to 0}\sin\left(\frac{x}{\pi}\right)=1$}
+    \choice{$\lim_{x\to 0}\sin\left(\frac{x}{\pi}\right) = -.866$}
+    \choice{$\lim_{x\to 0}\sin\left(\frac{x}{\pi}\right) = -.433$}
     \choice[correct]{The limit does not exist.}
   \end{multipleChoice}
   \begin{feedback}


### PR DESCRIPTION
When using a calculator to figure out the value of f(x) = sin(pi/x) at x of 0.1, 0.01, 0.001, and 0.0001, I generate the results 0.521, -0.717, -0.989, and 0.995 respectively. However, each of the questions have a correct answer of 0, which you get if you flip the fraction from sin(pi/x) to sin(x/pi). I'm using degrees on my calculator, which might be causing the confusion.

If it's not in the interest of the course to flip the fraction, it might be a good idea to mention somewhere that all calculations are in radians??

Loving the course so far, and the platform is amazing!