### PR TITLE
Added "z" into box definition

### DIFF
--- a/multipleIntegrals/digInIntegralsOverTrivialRegions.tex
+++ b/multipleIntegrals/digInIntegralsOverTrivialRegions.tex
@@ -30,7 +30,7 @@ R = \{(x,y):\text{$a\le x\le b$ and $c\le y\le d$}\}
 \]
 A box is defined as:
 \[
-R = \{(x,y):\text{$a\le x\le b$, $c\le y\le d$, and $p\le q$}\}
+R = \{(x,y,z):\text{$a\le x\le b$, $c\le y\le d$, and $p\le $z\le q$}\}
 \]
 Let's get to work!
 


### PR DESCRIPTION
I may be misunderstanding the text here, not sure... but later in the page you define a box with those three inequalities on x,y, and z, which makes sense. Is that what should be here?