### PR TITLE
Changed arguments to F in theorem definition

### DIFF
--- a/commonCoordinates/digInCylindricalCoordinates.tex
+++ b/commonCoordinates/digInCylindricalCoordinates.tex
@@ -190,7 +190,7 @@ and computing:
   \]
   Then: 
   \[
-  \iiint_R F(r,\theta,z)\d V = \int_\alpha^\beta\int_{g_1(\theta)}^{g_2(\theta)} \int_{G_1(r\cos(\theta),r\sin(\theta))}^{G_2(r\cos(\theta),r\sin(\theta))}F(r,\theta,z) \d z \ r\d r\d \theta.
+  \iiint_R F(r,\theta,z)\d V = \int_\alpha^\beta\int_{g_1(\theta)}^{g_2(\theta)} \int_{G_1(r\cos(\theta),r\sin(\theta))}^{G_2(r\cos(\theta),r\sin(\theta))}F(r\cos(\theta),r\sin(\theta),z) \d z \ r\d r\d \theta.
   \]
 \end{theorem}
 


### PR DESCRIPTION
Should "F(r, theta, z)" be "F(r*cos(theta), r*sin(theta), z)"? This is similar to the Fubini's theorem in the last section for polar coordinates, so shouldn't we change the arguments to F appropriately?