### PR TITLE
Change second one-sided signs

### DIFF
--- a/derivativeAsAFunction/digInTheDerivativeAsAFunction.tex
+++ b/derivativeAsAFunction/digInTheDerivativeAsAFunction.tex
@@ -228,7 +228,7 @@ The last limit does not exist. Recall
 \]
 and
 \[
-\lim_{h\to 0^-} \dfrac{|h| }{h}= \lim_{h\to 0^-} \dfrac{\answer[given]{-h} }{h}=\lim_{h\to 0^+} \answer[given]{-1}=\answer[given]{-1}
+\lim_{h\to 0^-} \dfrac{|h| }{h}= \lim_{h\to 0^-} \dfrac{\answer[given]{-h} }{h}=\lim_{h\to 0^-} \answer[given]{-1}=\answer[given]{-1}
 \]
 Since $f'(0)$ is not defined, $f$ is \textbf{not differentiable} at $0$, and , therefore,  $0$ is not in the domain of $f'$.
 


### PR DESCRIPTION
In the example, we are supposed to find the one-sided limits of f(0) for the absolute value function. Towards the end of the one sided limit of f|0| as h goes to 0 from the left, the "-" sign magically becomes a "+". Small typo. Love this platform, still working through Calc 1.