### PR TITLE
Typo: Missing minus sign

### DIFF
--- a/productAndQuotientRules/digInProductRuleAndQuotientRule.tex
+++ b/productAndQuotientRules/digInProductRuleAndQuotientRule.tex
@@ -287,7 +287,7 @@ With a bit of algebra, both of these simplify to
 &=\frac{f'(4)g(4)-f(4)g'(4)}{\left(g(4)\right)^2}\\
 &=\frac{5(-2)-3\cdot2}{\left(-2\right)^2}\\
 &=\frac{-10-6}{4}\\
-&=4
+&=-4
 \end{align*}
 	   \end{explanation}
 \end{example} 


### PR DESCRIPTION
-16/4 = -4. Currently it's 4.

Pretty stoked to get to the chain rule next!! Loving everything about Ximera Calc 1!