### PR TITLE
Suggestion: Intermediate step

### DIFF
--- a/implicitDifferentiation/digInDerivativesOfInverseExponentialFunctions.tex
+++ b/implicitDifferentiation/digInDerivativesOfInverseExponentialFunctions.tex
@@ -94,6 +94,7 @@ From the derivative of the natural logarithm, we can deduce another fact:
     So we may write
     \begin{align*}
       \ddx \log_b(x) &= \ddx \frac{\ln(x)}{\answer[given]{\ln(b)}}\\
+      &= \frac{1}{\n(b)} \ddx \ln(x).
       &= \answer[given]{\frac{1}{x\ln(b)}}.
     \end{align*}
   \end{explanation}


### PR DESCRIPTION
While working through the formula on my own, it took me a minute to realize that 1/ln(b) was a constant, so by the (multiplying by a) constant rule, we could move it in front of the derivative, and continue by taking the derivative of the ln of x. This of course leads to our final answer 1 / ( x * ln(b)).

Having this extra step might make it a little clearer to someone learning calculus to see how we get to the answer. Alternatively, leaving it out might force them to think it through (like I had to).

So, as the instructor, this is totally your call whether to accept or delete the pull request (as I have no idea what the intention behind the formula as written is).

BTW, just figured out that I can watch the archived lectures on Coursera, AND work through this material as a second primary text!! Awesome!! Y'all are doing great things at THE Ohio State University, lol. I'm a Trojans fans myself. It's going to be a few seasons before we can contend on the national stage again.