### PR TITLE
Typo: samples pints => sample points

### DIFF
--- a/antiderivativesAndArea/digInRelatingVelocityAndPositionAntiderivativesAndAreas.tex
+++ b/antiderivativesAndArea/digInRelatingVelocityAndPositionAntiderivativesAndAreas.tex
@@ -537,7 +537,7 @@ velocity equal to the velocity at the beginning of each time interval.
    t
 \end{align*}
 Using sigma notation, notation for the length of each time interval,
-$\Delta t=\frac{4-0}{n}=\frac{4}{n}$, and notation for sample pints,
+$\Delta t=\frac{4-0}{n}=\frac{4}{n}$, and notation for sample points,
 we write
 
   \[


### PR DESCRIPTION
Though I could use a sample pint while trying to wrap my head around antiderivatives...