### PR TITLE
Remove redundant phrase

### DIFF
--- a/sequences/digInSequences.tex
+++ b/sequences/digInSequences.tex
@@ -487,8 +487,7 @@ Continuing in the same way, we find:
 \begin{question}
 
 Since none of the terms in the original sequence $\{a_n\}$ were
-negative, we define another new sequence $\{c_n\}_{n=1}$ by the rule
-define another new sequence $\{c_n\}_{n=1}$ by the rule below.
+negative, we define another new sequence $\{c_n\}_{n=1}$ by the rule below.
 \[
 c_n = \sqrt[n]{a_n} .
 \]


### PR DESCRIPTION
Removed a phrase in the sentence that was redundantly written twice in a row.