### PR TITLE
Edit sentences

### DIFF
--- a/sumsOfSequences/digInWhatIsASeries.tex
+++ b/sumsOfSequences/digInWhatIsASeries.tex
@@ -63,7 +63,7 @@ A student, feeling quite clever, decides to illustrate the sum by drawing a squa
 There are two quantities of which we can keep track now.
 \begin{itemize}
 \item Call the area shaded this step $A_1$.  Then, we have $A_1=\answer[given]{1/2}$.
-\item Call and the total shaded area  of the square $S_1$.  Then, we have $S_1=\answer[given]{1/2}$.
+\item Call the total shaded area of the square $S_1$.  Then, we have $S_1=\answer[given]{1/2}$.
 \end{itemize}
 
 \paragraph{Step 2:} Shade the bottom half of the unshaded region.  
@@ -93,7 +93,7 @@ There are two quantities of which we can keep track now.
 
 \begin{itemize}
 \item Call the area shaded this step $A_2$.  Then, we have $A_2=\answer[given]{1/4}$.
-\item Call and the total shaded area  of the square $S_2$.  Then, we have $S_2=\answer[given]{3/4}$.
+\item Call the total shaded area of the square $S_2$.  Then, we have $S_2=\answer[given]{3/4}$.
 \end{itemize}
 
 Visually, notice that we can find $S_2$ by noting
@@ -133,7 +133,7 @@ Analytically, we can write $S_2=A_1+A_2.$
 
 \begin{itemize}
 \item Call the area shaded this step $A_3$.  Then, we have $A_3=\answer[given]{1/8}$.
-\item Call and the total shaded area  of the square $S_3$.  Then, we have $S_3=\answer[given]{7/8}$.
+\item Call the total shaded area of the square $S_3$.  Then, we have $S_3=\answer[given]{7/8}$.
 \end{itemize}
 
 We can think of $S_3$ visually or analytically. 


### PR DESCRIPTION
Removed the superfluous word "and" from three similar sentences, along with an unnecessary space.