### PR TITLE
Remove redundant word

### DIFF
--- a/remainders/digInRemaindersIntegralTest.tex
+++ b/remainders/digInRemaindersIntegralTest.tex
@@ -410,7 +410,7 @@ We must compute
 \begin{align*}
 \int_{2}^{\infty} \frac{\ln(x)}{x^2} \d x &= \lim_{b \to \infty} \int_2^b  \frac{\ln(x)}{x^2} \d x .\\
 \end{align*}
-To find the necessary antiderivative, we use use integration by parts.
+To find the necessary antiderivative, we use integration by parts.
 
 \begin{align*}
 u&= \answer{\ln(x)} & \d v&= \answer{\frac{1}{x^2}} \d x \\


### PR DESCRIPTION
The word "use" was written twice in a row unnecessarily.