### PR TITLE
Ordered when the problems expand

### DIFF
--- a/divergenceTest/exercises/conceptualQuestionSumOfPartialSum1.tex
+++ b/divergenceTest/exercises/conceptualQuestionSumOfPartialSum1.tex
@@ -70,7 +70,7 @@ Thus,
 \end{exercise}
 
 
-\end{exercise}
+
 Thus, if we are only given that $\sum_{k=1}^{\infty} s_k$ diverges:
 \begin{multipleChoice}
 \choice{$\sum_{k=1}^{\infty} a_k$ converges to $0$.}
@@ -79,8 +79,7 @@ Thus, if we are only given that $\sum_{k=1}^{\infty} s_k$ diverges:
 \choice{$\sum_{k=1}^{\infty} a_k$ diverges.}
 \end{multipleChoice}
 \end{exercise}
-
-
+\end{exercise}
 
 
 \end{exercise}


### PR DESCRIPTION
One of the exercises was nested such that one of the problems was displayed: "Suppose that it is known that $\sum_{k=1}^{\infty} s_k$ diverges.  Consider the following examples: Thus, if we are only given that $\sum_{k=1}^{\infty} s_k$ diverges: ...".

I believe this to occur because both exercises have the same root exercise so they aren't appearing sequentially rather they are appearing one after another. It seemed like the conclusion of the problem was asked at the beginning.