### PR TITLE
Remove duplicate questions on same page

### DIFF
--- a/review/refreshPrerequisites/definiteIntegrals.tex
+++ b/review/refreshPrerequisites/definiteIntegrals.tex
@@ -58,13 +58,6 @@ In this exercise, we evaluate several definite integrals using basic antiderivat
 \end{exercise}
 
 
-
-\begin{exercise} Calculate:
-\[
-\int_0^1 \frac{1}{1 + x} \d x =\answer{\ln(2)}
-\]
-\end{exercise}
-
 \begin{exercise} Calculate:
 \[
 \int_2^5 \frac{1}{3+3x} \d x =\answer{\frac{\ln(2)}{3}}


### PR DESCRIPTION
Duplicate of the first exercise on page (line 17).

`\int_0^1 \frac{1}{1 + x}` = `\int_0^1 \frac{1}{x + 1}`