### PR TITLE
Fix typo in digInDirectionalDerivative

### DIFF
--- a/directionalDerivativeAndChainRule/digInDirectionalDerivative.tex
+++ b/directionalDerivativeAndChainRule/digInDirectionalDerivative.tex
@@ -630,7 +630,7 @@ Recalling that this limit is $0$ in the first place gives
 \[
 \lim_{t \to 0} \frac{F( \vec{a}+t\uvec{u})-F(\vec{a})}{t} - \grad{F}(\vec{a}) \dotp \uvec{u} = 0,
 \]
-and since by definition, $D_{\uvec{u}}(\vec{a}) = \lim_{t \to 0} \frac{F( \vec{a}+t\uvec{u})-F(\vec{a})}{t}$, we have
+and since by definition, $D_{\uvec{u}}(F(\vec{a})) = \lim_{t \to 0} \frac{F( \vec{a}+t\uvec{u})-F(\vec{a})}{t}$, we have
 
 \[
 D_{\uvec{u}} (F(\vec{a})) - \grad{F}(\vec{a}) \dotp \uvec{u} = 0.


### PR DESCRIPTION
Maybe $(D_{\vec{\mathbf{u}}} F)(\vec{\mathbf{a}})$ is better notation, but this is consistent with the rest of the page.