### PR TITLE
Update improperIntegralsGuided1.tex

### DIFF
--- a/improperIntegrals/exercises/improperIntegralsGuided1.tex
+++ b/improperIntegrals/exercises/improperIntegralsGuided1.tex
@@ -33,7 +33,7 @@ Now we determine the integral
 Now we take the limit 
 
 \[
-\lim_{b \to \infty} \int_{0}^{N} xe^{-x^{2}} \d x=\lim_{b \to \infty} \frac{-1}{2} \left( e^{-N^{2}}-1 \right) = 
+\lim_{b \to \infty} \int_{0}^{b} xe^{-x^{2}} \d x=\lim_{b \to \infty} \frac{-1}{2} \left( e^{-b^{2}}-1 \right) = 
 \answer{ \frac{1}{2}} 
 \]
 


### PR DESCRIPTION
toward the end of the problem it should be b in the upperbound of the integral not N so changed:

\[
\lim_{b \to \infty} \int_{0}^{N} xe^{-x^{2}} \d x=\lim_{b \to \infty} \frac{-1}{2} \left( e^{-N^{2}}-1 \right) =  \answer{ \frac{1}{2}} 
\]

to:
Now we take the limit 
\lim_{b \to \infty} \int_{0}^{b} xe^{-x^{2}} \d x=\lim_{b \to \infty} \frac{-1}{2} \left( e^{-b^{2}}-1 \right) =  \answer{ \frac{1}{2}}