### PR TITLE
wording of the problem

### DIFF
--- a/accumulatedCrossSections/exercises/setUpCrossSectionGuided.tex
+++ b/accumulatedCrossSections/exercises/setUpCrossSectionGuided.tex
@@ -53,7 +53,7 @@ Hence, we integrate:
 \choice{with respect to $y$.}
 \end{multipleChoice}
 
-We indicate the useful quantities on the base a prototypical slice:
+We draw the square cross sections below:
 
 
             \begin{image}
@@ -90,7 +90,7 @@ We indicate the useful quantities on the base a prototypical slice:
             \end{tikzpicture}
             \end{image}
             
-The cross sections are square.  One of the sides lies on the base in the $xy$-plane, while the other extends vertically above the $xy$-plane.  We want to use the formula:
+Since the cross section is a square, we let one of its sides lie on the base of the $xy$-plane, while the other extend vertically above the $xy$-plane.  We want to use the formula:
 
 \[ 
 V= \int_{x=a}^{x=b} A \d x


### PR DESCRIPTION
The wording of perpendicular to the x-axis was strange. I took out the first sentence: We indicate the useful quantities on the base a prototypical slice:

and made the sentence after the graph be:
Since the cross section is a square, we let one of its sides lie on the base of the $xy$-plane, while the other extend vertically above the $xy$-plane.