### PR TITLE
Update calculateArclength5.tex

### DIFF
--- a/lengthOfCurves/exercises/calculateArclength5.tex
+++ b/lengthOfCurves/exercises/calculateArclength5.tex
@@ -46,7 +46,7 @@ s= \int_{x=\answer{0}}^{x=\answer{r}} \answer{\frac{r}{\sqrt{r^2-x^2}}} \d x
 \]
 
 \begin{exercise}
-Referring to a table, if necessary, $\int \frac{r}{\sqrt{r^2-x^2}} = \answer{r \arcsin(x/r)}$+C.  Thus,
+Referring to a table, if necessary, $\int \frac{r}{\sqrt{r^2-x^2}}dx = \answer{r \arcsin(x/r)}$+C.  Thus,
 
 \[
 s= \eval{\answer{r \arcsin(x/r)}}_0^r


### PR DESCRIPTION
Here:
Referring to a table, if necessary, $\int \frac{r}{\sqrt{r^2-x^2}}dx = \answer{r \arcsin(x/r)}$+C.  Thus,

dx after the integrand was missing so I added it.