### PR TITLE
Update calculateATaylorPolynomialGuided.tex

### DIFF
--- a/introductionToTaylorSeries/exercises/calculateATaylorPolynomialGuided.tex
+++ b/introductionToTaylorSeries/exercises/calculateATaylorPolynomialGuided.tex
@@ -71,7 +71,7 @@ So, the series for $4 \cos(x)$ by multiplying the series above by $4$:
 
 \end{exercise}
 %%%%%%%%%%%%%%%%%%%%%
-Now, note that we have exhibited several terms in the relevant series.  To find the sum of the first four nonzero terms in the sum, note that if we add the the expressions:
+Now, note that we have exhibited several terms in the relevant series.  To find the sum of the first four nonzero terms in the sum, note that if we add the expressions:
 
 \[e^{2x} = 1+2x+2x^2+\frac{4}{3}x^3+\frac{2}{3}x^4+ \cdots\]
 
@@ -90,10 +90,10 @@ Note that when we add these, the result will only be valid up to the lower/lowes
 
 \[ 
 \begin{array}{rlrrrrr}
-e^{2x} &= 1&+2x&+2x^2&+\frac{4}{3}x^3&+\frac{2}{3}x^4&+ \cdots \\ [3ex]
+e^{2x} &= 1&+2x&+2x^2&+\frac{4}{3}x^3&+\frac{2}{3}x^4&+ \cdots \\ 
 4 \cos(x) &= 4& &-2x^2& &+\frac{1}{6}x^4& + \cdots \\[2ex]
-\hline \\ [1ex]
-e^{2x}+4\cos(2x) & = \answer{5}&+\answer{2}x&+\answer{0}x^2&+\answer{\frac{4}{3}}x^3&+\answer{\frac{5}{6}}x^4& +\cdots
+\hline \\ 
+e^{2x}+4\cos(x) & = \answer{5}&+\answer{2}x&+\answer{0}x^2&+\answer{\frac{4}{3}}x^3&+\answer{\frac{5}{6}}x^4& +\cdots
 \end{array}
 \]
 (add the coefficients of the like powers together)


### PR DESCRIPTION
In the sentence:
Now, note that we have exhibited several terms in the relevant series.  To find the sum of the first four nonzero terms in the sum, note that if we add the the expressions:

I took out one of "the"
Also later in the table for the two terms separately added together, they had (3ex)4cos(x) but it should be just 4cos(x) and afterwards when they add the terms from e^2x and 4cos(x) they get (1ex)e^2x +4cos(2x) but it should be e^(2x)+4cos(x) so I changed them. Also in a multiple choice question before it, it says the series e^(2x) +4cos(x) is valid up to and the answer it is up to x^4 term but this is confusing since these are valid up to any power.