### PR TITLE
Update l'HopitalsRuleReview.tex

### DIFF
--- a/review/refreshLimits/l'HopitalsRuleReview.tex
+++ b/review/refreshLimits/l'HopitalsRuleReview.tex
@@ -26,10 +26,8 @@ and $\lim_{x \to a} \frac{f'(x)}{g'(x)}$ exists, then
 \]
 \end{theorem}
 
-The theorem above can be generalized to handle the case where $x \to \infty$ as well, and the results can be summarized by noting that when we have functions $f$ and $g$ that meet the criteria of the theorem
-
 \begin{quote}
-When a limit has the indeterminate form $\frac{0}{0}$ or $\pm \frac{\infty}{\infty}$, we can apply L'H\^{o}pital's Rule.
+The theorem above can be generalized to handle the case where $x \to \infty$ as well. Summarizing: if we have functions $f$ and $g$ that meet the criteria of the theorem and the limit has the indeterminate form $\frac{0}{0}$ or $\pm \frac{\infty}{\infty}$, then we can apply L'H\^{o}pital's Rule.
 \end{quote}
 
 \begin{example}


### PR DESCRIPTION
Changed:
"The theorem above can be generalized to handle the case where $x \to \infty$ as well, and the results can be summarized by noting that when we have functions $f$ and $g$ that meet the criteria of the theorem

\begin{quote}
When a limit has the indeterminate form $\frac{0}{0}$ or $\pm \frac{\infty}{\infty}$, we can apply L'H\^{o}pital's Rule. \end{quote}"

To:

\begin{quote}
The theorem above can be generalized to handle the case where $x \to \infty$ as well. Summarizing: if we have functions $f$ and $g$ that meet the criteria of the theorem and the limit has the indeterminate form $\frac{0}{0}$ or $\pm \frac{\infty}{\infty}$, then we can apply L'H\^{o}pital's Rule. \end{quote}

The sentences were not complete and did not match before.