### PR TITLE
Update additionalProblem1.tex

### DIFF
--- a/review/refreshInequalities/additionalProblem1.tex
+++ b/review/refreshInequalities/additionalProblem1.tex
@@ -34,11 +34,7 @@
   \end{multipleChoice}
   
   \begin{hint}
-  Note that $|2(x -1)^2| = 2|x-1|^2$.  Analytically, if $2|x-1|^2 <8$, we have $|x-1|^2<4$, which requires that $x-1 < \answer{2}$ \emph{and} $x-1 > \answer{-2}$.  this can be written obtained as well by not dropping the absolute value and noting that 
-  
-\[
-\textrm{If } |x-1|^2 <4, \textrm{ then } |x-1| <2. 
-\]
+  Note that $|2(x -1)^2| = 2|x-1|^2$.  Analytically, if $2|x-1|^2 <8$, we have $|x-1|^2<4$, leading to $|x-1|<2$, which  requires that $x-1 < \answer{2}$ \emph{and} $x-1 > \answer{-2}$.  
   
   \end{hint}
   


### PR DESCRIPTION
Changed the hint at the end from:
Note that $|2(x -1)^2| = 2|x-1|^2$.  Analytically, if $2|x-1|^2 <8$, we have $|x-1|^2<4$, which requires that $x-1 < \answer{2}$ \emph{and} $x-1 > \answer{-2}$.  this can be written obtained as well by not dropping the absolute value and noting that \[
\textrm{If } |x-1|^2 <4, \textrm{ then } |x-1| <2.  \]

To just:

 \begin{hint}
  Note that $|2(x -1)^2| = 2|x-1|^2$.  Analytically, if $2|x-1|^2 <8$, we have $|x-1|^2<4$, leading to $|x-1|<2$, which  requires that $x-1 < \answer{2}$ \emph{and} $x-1 > \answer{-2}$.  

  \end{hint}