### PR TITLE
Update trigonometricIntegrals.tex

### DIFF
--- a/review/refreshIntegrationTechniques/trigonometricIntegrals.tex
+++ b/review/refreshIntegrationTechniques/trigonometricIntegrals.tex
@@ -14,7 +14,7 @@
 
 \begin{exercise}
 
-We studied trigonometric integrals that involve products of trigonometric functions with the same argument.  In these integrals, it was useful to have combinations of 
+We studied trigonometric integrals that involve products of trigonometric functions.  In these integrals, it was useful to have combinations of 
 
 \begin{itemize}
 \item sines and cosines
@@ -32,7 +32,7 @@ As first reminder, fill out the following table.
 \end{exercise}
 
 \begin{example}
-A helpful initial strategy is to try a substitution by setting $u$ equal to one of the trigonometric functions.  After saving a copy of the derivative for the substitution, if there is even number of the other trig function, we use the appropriate Pythagorean identity to convert it.
+A helpful initial strategy is to try a substitution by setting $u$ equal to one of the trigonometric functions.  After saving a copy of the derivative of $u$, if there is an even number of the other trig function, we use the appropriate Pythagorean identity to convert it to a function of $u$.
 
 Evaluate  $\int \sin^3(x) \cos^2(x) \d x$.
 


### PR DESCRIPTION
In the sentence:
We studied trigonometric integrals that involve products of trigonometric functions with the same argument.  In these integrals, it was useful to have combinations of

I took out "with the same argument". 

Also I changed:

A helpful initial strategy is to try a substitution by setting $u$ equal to one of the trigonometric functions.  After saving a copy of the derivative for the substitution, if there is even number of the other trig function, we use the appropriate Pythagorean identity to convert it.

To:

A helpful initial strategy is to try a substitution by setting $u$ equal to one of the trigonometric functions.  After saving a copy of the derivative of $u$, if there is an even number of the other trig function, we use the appropriate Pythagorean identity to convert it to a function of $u$.