### PR TITLE
Update divergenceTestCompute2.tex

### DIFF
--- a/divergenceTest/exercises/divergenceTestCompute2.tex
+++ b/divergenceTest/exercises/divergenceTestCompute2.tex
@@ -27,7 +27,7 @@ Indeed, since $\lim_{n \to \infty} (-1)^n \frac{3n^2}{2n^2+4} = \answer{DNE}$, t
 Consider the sequence $\{b_n\}_{n=1}$ given by $b_n = \sin \left(\frac{1}{n}\right)$.  Consider the series $\sum_{k=1}^{\infty} b_k$:
 
 \begin{multipleChoice}
-\choice[correct]{The series diverges by the divergence test.}
+\choice{The series diverges by the divergence test.}
 \choice{The series converges by the divergence test.}
 \choice[correct]{The divergence test is inconclusive.}
 \end{multipleChoice}


### PR DESCRIPTION
For the second question with bn=sin(1/n) the first and third choices were both coded as correct but the answer is only the third option which is the divergence test is inconclusive as it says after answering the question correctly. So I took out the code [correct] before the first choice.