### PR TITLE
Update ratioTestAndPolynomials.tex

### DIFF
--- a/ratioAndRootTest/exercises/ratioTestAndPolynomials.tex
+++ b/ratioAndRootTest/exercises/ratioTestAndPolynomials.tex
@@ -25,7 +25,7 @@ Let $p(x)$ be a polynomial.  Then:
 To gain a little practice, suppose that $p(x) = x^5$.  Then the limit to evaluate is:
 
 \[
-\lim_{n \to \infty} \frac{p(n+1)}{p(n)} = \answer{\frac{(n+1)^5}{n^5}}
+\lim_{n \to \infty} \frac{p(n+1)}{p(n)} = \lim_{n \to \infty} \answer{\frac{(n+1)^5}{n^5}}
 \]
 The numerator is a polynomial of degree $\answer{5}$, and the coefficient of the $n^5$ term is $\answer{1}$.
 
@@ -36,7 +36,7 @@ Hence, the limit is $\answer{1}$.
 \begin{exercise}
 To explore this a little more, now set $p(x) = x^5+4x^3+7$.  Then:
 \[
-\lim_{n \to \infty} \frac{p(n+1)}{p(n)} = \answer{\frac{(n+1)^5+4(n+1)^3+7}{n^5+4n^3+7}}
+\lim_{n \to \infty} \frac{p(n+1)}{p(n)} = \lim_{n \to \infty} \answer{\frac{(n+1)^5+4(n+1)^3+7}{n^5+4n^3+7}}
 \]
 
 Note that $(n+1)^5$ is a polynomial of degree $\answer{5}$, $(n+1)^3$ is a polynomial of degree $\answer{3}$, so without expanding any of these powers out, the numerator is a polynomial of degree $\answer{5}$, and the coefficient of the $n^5$ term is $\answer{1}$.


### PR DESCRIPTION
After to gain a little practice the following equation is given:

\lim_{n \to \infty} \frac{p(n+1)}{p(n)} = \answer{\frac{(n+1)^5}{n^5}}

But the answer has n in it and there should be a limit before it so I put the limit before the answer as part of the question. This happens in the question after this and I fixed that as well.