### PR TITLE
Update 6_Q2-1151.tex

### DIFF
--- a/asymptotesAsLimits/exercises/6_Q2-1151.tex
+++ b/asymptotesAsLimits/exercises/6_Q2-1151.tex
@@ -39,7 +39,8 @@ Determine if the following limits exist. If they exist, compute them \textbf{ana
     \[
     f(x) = \answer{\frac{x}{x-4}}.
     \]
-    \begin{exercise}As $x$ approaches $4$ from the right, $x-4$ is \wordChoice{\choice[correct]{positive}\choice{negative}\choice{zero}} and approaching zero while at the same time, $x$ approaches $\answer{4}$. \begin{exercise} Therefore, as $x$ approaches $4$ from the right, $f(x)$ is positive and grows \wordChoice{\choice[correct]{arbitrarily large}\choice{arbitrarily small}}. \begin{exercise} Hence, 
+    \begin{exercise}As $x$ approaches $4$ from the right, $x-4$ is \wordChoice{\choice[correct]{positive}\choice{negative}\choice{zero}} and approaching zero.
+    \begin{exercise} Therefore, as $x$ approaches $4$ from the right, $f(x)$ is positive and grows \wordChoice{\choice[correct]{arbitrarily large}\choice{arbitrarily small}}. \begin{exercise} Hence, 
     \[
     \lim_{x\to 4}f(x)=\answer{DNE}.
     \]


### PR DESCRIPTION
Problem url:
https://ximera.osu.edu/mooculus/asymptotesAsLimits/exercises/exerciseList/asymptotesAsLimits/exercises/6_Q2-1151

took out while at the same time, $x$ approaches $\answer{4}$ in:

As $x$ approaches $4$ from the right, $x-4$ is .... and approaching zero while at the same time, $x$ approaches ......

So they have to put in 4 at the end and it seems repetitive. I took out the ending:

As $x$ approaches $4$ from the right, $x-4$ is .... and approaching zero.