### PR TITLE
Update comparisonTestAWalkthroughHowItWorks.tex

### DIFF
--- a/comparisonTests/exercises/comparisonTestAWalkthroughHowItWorks.tex
+++ b/comparisonTests/exercises/comparisonTestAWalkthroughHowItWorks.tex
@@ -103,7 +103,7 @@ In the present case, it would be very difficult to establish an explicit formula
 \choice{If $\{s_n\}$ is increasing, we can show $\lim_{n \to \infty} s_n$ does not exist by showing it is not bounded below.}
 \end{selectAll}
 
-Since we have reasoned before that the \emph{sequences} $\frac{k}{k^3+2k+1}$ and $\frac{1}{k^2}$ should be asymptotically similar (behave the same way as $k$ grows arbitrarily large, it is reasonable to hope that:
+Since we have reasoned before that the \emph{sequences} $\frac{k}{k^3+2k+1}$ and $\frac{1}{k^2}$ should be asymptotically similar (behave the same way as $k$ grows arbitrarily large) it is reasonable to hope that:
 
 \begin{multipleChoice}
 \choice[correct]{$\sum_{k=1}^{\infty} \frac{k}{k^3+2k+1}$ converges.}


### PR DESCRIPTION
Problem url:
https://ximera.osu.edu/mooculus/comparisonTests/exercises/exerciseList/comparisonTests/exercises/comparisonTestAWalkthroughHowItWorks

a parenthesis was opened here and not closed so I fixed it:

Since we have reasoned before that the \emph{sequences} $\frac{k}{k^3+2k+1}$ and $\frac{1}{k^2}$ should be asymptotically similar (behave the same way as $k$ grows arbitrarily large) it is reasonable to hope that: