### PR TITLE
Update tangentLinesBothWays.tex

### DIFF
--- a/parametricEquations/exercises/tangentLinesBothWays.tex
+++ b/parametricEquations/exercises/tangentLinesBothWays.tex
@@ -61,11 +61,9 @@ Follow the instructions in the earlier exercise to draw a picture of this on Des
 \end{exercise}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{exercise}
-Of course, we can also find a description of our curve in Cartesian coordinates, then find the tangent line.  Notice that given our parametric equations that $x^3=\answer{t^6}$ and that $y^2=\answer{t^6}$.
+Of course, we can also find a description of our curve in Cartesian coordinates, then find the tangent line.  Notice that given our parametric equations that $x^3=\answer{t^6}$ and that $y^2=\answer{t^6}$ (give answers in terms of $t$). 
 
-(give answers in terms of $t$)
-
-Thus the the $x$-coordinate and $y$-coordinate of any point on our given curve satisfies $y^{\answer{2}}=x^{\answer{3}}$. 
+Thus the $x$-coordinate and $y$-coordinate of any point on our given curve satisfies $y^{\answer{2}}=x^{\answer{3}}$. 
 
 We will use implicit differentiation since the above equation does not represent a function.  Differentiating both sides with respect to $x$ gives:
 


### PR DESCRIPTION
Problem url:
https://ximera.osu.edu/mooculus/parametricEquations/exercises/exerciseList/parametricEquations/exercises/tangentLinesBothWays

Fixed the sentence:
Thus the the $x$-coordinate and $y$-coordinate of any point on our given curve satisfies $y^{\answer{2}}=x^{\answer{3}}$.

(took out one of the "the" at the beginning)
Also put the hint in parenthesis in:

Notice that given our parametric equations that $x^3=\answer{t^6}$ and that $y^2=\answer{t^6}$ (give answers in terms of $t$).

Right after the answers so they see it. Before it was beneath the answer and is likely to be noticed after one answers the question.