### PR TITLE
Update tangentLine1.tex

### DIFF
--- a/parametricEquations/exercises/tangentLine1.tex
+++ b/parametricEquations/exercises/tangentLine1.tex
@@ -29,7 +29,7 @@ Using the chain rule allows us to write $\frac{dy}{dx} = \frac{dy/dt}{dx/dt}$.
 
 %%%Horizontal Tangent Lines%%%%%%
 \begin{exercise}
-We can find the horizontal tangent lines by examining when the the derivative is $0$.
+We can find the horizontal tangent lines by examining when the derivative is $0$. That is when $dx/dt=0$.
 
 How many horizontal tangent lines does the curve $C$ have?
 \begin{multipleChoice}
@@ -57,7 +57,7 @@ You should check your work with Desmos.  Follow the instructions in the previous
 
 %%%vertical Tangent Lines%%%%%%
 \begin{exercise}
-We can find the vertical tangent lines by examining when the the derivative becomes infinite.
+We can find the vertical tangent lines by examining when the derivative becomes infinite.
 
 How many vertical tangent lines does the curve $C$ have?
 \begin{multipleChoice}


### PR DESCRIPTION
Problem url:
https://ximera.osu.edu/mooculus/parametricEquations/exercises/exerciseList/parametricEquations/exercises/tangentLine1

Two sentences had the the and removed one of the ''the'' Also in:

We can find the horizontal tangent lines by examining when the derivative is $0$. That is when $dx/dt=0$.

have added "That is when $dx/dt=0$". because most books most books find them by setting dx/dt=0. In the problem this is not mentioned and they only say we find it by examining when the derivative becomes infinite. It is good to also mention this since it is easier to remember.