### PR TITLE
Update partialFractionsThinkAboutIt2.tex

### DIFF
--- a/partialFractions/exercises/partialFractionsThinkAboutIt2.tex
+++ b/partialFractions/exercises/partialFractionsThinkAboutIt2.tex
@@ -26,19 +26,19 @@ If we want to integrate this, partial fraction decomposition would be a good tec
 The partial fraction decomposition for this expression is:
 
 \[
-\frac{3x^2-8x+1}{x^3-2x^2+x}= \frac{\answer{A}}{x}+\answer{\frac{B}{(x-1)^2}+\frac{C}{x-1}}
+\frac{3x^2-8x+1}{x^3-2x^2+x}= \frac{\answer{A}}{x}+\answer{\frac{B}{x-1}+\frac{C}{(x-1)^2}}
 \]
 (Use $A$, $B$, and $C$ for the constants and list the terms in the order written in the factored form and write the higher powers of repeated terms first)
 
-Solving for these constants, we find: $A = \answer{1}$, $B=\answer{-4}$, and $C=\answer{2}$ and we conclude:
+Solving for these constants, we find: $A = \answer{1}$, $B=\answer{2}$, and $C=\answer{-4}$ and we conclude:
 
 \[
-\frac{3x^2-8x+1}{x^3-2x^2+x}= \answer{\frac{1}{x}+\frac{-4}{(x-1)^2}+\frac{2}{x-1}}
+\frac{3x^2-8x+1}{x^3-2x^2+x}= \answer{\frac{1}{x}+\frac{2}{x-1}+\frac{-4}{(x-1)^2}}
 \]
 
 Thus, we conclude:
 \[
-\int \frac{3x^2-8x+1}{x^3-2x^2+x} \d x = \int \frac{1}{x}-\frac{4}{(x-1)^2}+\frac{2}{x-1} \d x = \answer{\ln|x|+\frac{4}{x-1}+2\ln|x-1| +C}
+\int \frac{3x^2-8x+1}{x^3-2x^2+x} \d x = \int \frac{1}{x}+\frac{2}{x-1}-\frac{4}{(x-1)^2} \d x = \answer{\ln|x|+2\ln|x-1|+\frac{4}{x-1} +C}
 \]
 (Use $C$ for the constant of integration)
 


### PR DESCRIPTION
https://ximera.osu.edu/mooculus/partialFractions/exercises/exerciseList/partialFractions/exercises/partialFractionsThinkAboutIt2

I changed the order of partial fraction decomposition. We usually have them in ascending order:

A/(x-1) + B/(x-1)^2

Here in the first part of the problem they had 
B/(x-1)^2 +C/(x-1)
then later at the end give the order /(x-1) + /(x-1)^2. That is in first part:
![image](https://github.com/mooculus/calculus/assets/156558883/ffb3559f-c7d0-47db-806f-0137e6f744fc)

then in second part:
![image](https://github.com/mooculus/calculus/assets/156558883/c5a82712-699a-4a9e-aa0f-4e2c2289cdee)

I changed the first part to ascending order and changed the rest of the part to match the new setup (the constants). 