### PR TITLE
Update basicCrossSection1.tex

### DIFF
--- a/accumulatedCrossSections/exercises/basicCrossSection1.tex
+++ b/accumulatedCrossSections/exercises/basicCrossSection1.tex
@@ -53,7 +53,7 @@ An integral that gives the volume of the solid is:
 
 Evaluating it, we find the volume of the solid is $\answer{ 256 \pi/15}$ cubic units.	
 
-(type an exact answer in terms of $\pi$)
+(You can use technology to find the exact answer in terms of $pi$.)
 	\end{exercise}
 	\end{exercise}
 	\end{exercise}


### PR DESCRIPTION
https://ximera.osu.edu/mooculus/accumulatedCrossSections/exercises/exerciseList/accumulatedCrossSections/exercises/basicCrossSection1

Changed the parenthesis at the end to:
(You can use technology to find the exact answer in terms of $pi$.) The integral at the end gets to be:
![image](https://github.com/mooculus/calculus/assets/156558883/d1159c97-4c23-4d48-88d7-c41a3d61902a)
