### PR TITLE
Update liftingProblemConicalTank1.tex

### DIFF
--- a/applicationsOfIntegration/exercises/liftingProblemConicalTank1.tex
+++ b/applicationsOfIntegration/exercises/liftingProblemConicalTank1.tex
@@ -13,7 +13,8 @@
 
 An inverted conical tank has base with diameter $6\unit{m}$ and height
 $9\unit{m}$. Suppose the tank is filled to a height of $6\unit{m}$
-with acetone ($\rho=785 \unit{kg}/\unit{m}^3$). Find the work required
+with acetone \\
+($\rho=785 \unit{kg}/\unit{m}^3$). Find the work required
 to pump the acetone out of the tank (use $g=9.8\unit{m}/\unit{s}^2$).
 \begin{image}
 \begin{tikzpicture}
@@ -67,8 +68,11 @@ Set the height $y=0$ at the base of the tank.  We want to use the formula:
 \[ 
 W = \int_{y=0}^{y=b} \rho g A(y) d(y) \d y
 \]
-
-Since $b$ is the height to which the tank is filled, $b=\answer{6}$.
+Recall property of similar triangles: if a triangle is within another triangle like in the figure above with height and base of the large triangle denoted as H and B and the height and base of the small triangle as h and b then 
+\[
+\frac{h}{H}= \frac{b}{B}
+\]
+ Since $b$ is the height to which the tank is filled, $b=\answer{6}$.
 
 Since $h$ is the height to which the water must be moved, $h=\answer{9}$.
 


### PR DESCRIPTION
https://ximera.osu.edu/mooculus/applicationsOfIntegration/exercises/exerciseList/applicationsOfIntegration/exercises/liftingProblemConicalTank1


Added the property of similar triangle in the hint:

Recall property of similar triangles: if a triangle is within another triangle like in the figure above with height and base of the large triangle denoted as H and B and the height and base of the small triangle as h and b then  \[
\frac{h}{H}= \frac{b}{B}
\]
This has to do with similar triangles and it is good to remind them of it. Also I find the steps in hint not easy to follow to get the answer and it is easier without the questions they have in the hint but I didn't take them out. 