### PR TITLE
Update liftingProblemCylTank3.tex

### DIFF
--- a/applicationsOfIntegration/exercises/liftingProblemCylTank3.tex
+++ b/applicationsOfIntegration/exercises/liftingProblemCylTank3.tex
@@ -47,13 +47,13 @@ Denote the work required to pump the liquids out of the tank (again, when the ta
 
 Compute $W_{\text{Hg}}(10)$, the work required to pump the mercury out of the tank when $h=10$.  \[
 W_{\text{Hg}}(10) 
-	= \int_{y=\answer{0}}^{y=\answer{10}} \rho_{\text{Hg}} g \answer{25 \pi (20-y)} \d y = \answer[tolerance=10]{499542750 \pi }J
+	= \int_{y=\answer{0}}^{y=\answer{10}} \rho_{\text{Hg}} g \answer{25 \pi (20-y)} \d y = \answer[tolerance=10]{36750 \pi }\rho_{\text{Hg}} J
 \]
 
 Compute $W_{\text{H$_2$O}}\left(\frac{1}{2}\right)$, the work required to pump the water out of the tank when $h= \frac{1}{2}$.
 \[
 W_{\text{H$_2$O}}\left(\frac{1}{2}\right) 
-	= \int_{y=\answer{\frac{1}{2}}}^{y=\answer{20}} \rho_{\text{H$_2$O}} g \answer{25\pi (20-y)} \d y = \answer[tolerance=10]{46580625 \pi}J
+	= \int_{y=\answer{\frac{1}{2}}}^{y=\answer{20}} \rho_{\text{H$_2$O}} g \answer{25\pi (20-y)} \d y = \answer[tolerance=10]{46580.63 \pi} \rho_{\text{H$_2$O}} J
 \]
 
 Find a value for $h$ so that the work required to pump the mercury from the tank is equal to the work required to pump the water from the tank.  Express your final answer to 2 decimal places.


### PR DESCRIPTION
https://ximera.osu.edu/mooculus/applicationsOfIntegration/exercises/exerciseList/applicationsOfIntegration/exercises/liftingProblemCylTank3

Changed the way the answers are given. The answers become very large numbers and I changed the setting to answer \rho_... so that rho appears at the end and they don't have to multiply it out.
![image](https://github.com/mooculus/calculus/assets/156558883/e802c700-a470-4f0b-9a15-06ec1e2db7f3)

I changed the first answer to 36750 and let rho be given outside since 499542750/13593 = 36750. Also for the second one I divided: 46580625/1000 and wrote rho_H2O outside and made the answer: 46580.63. So they don't have to type very large numbers. 