### PR TITLE
Update computeTaylorPoly1.tex

### DIFF
--- a/approximatingFunctionsWithPolynomials/exercises/computeTaylorPoly1.tex
+++ b/approximatingFunctionsWithPolynomials/exercises/computeTaylorPoly1.tex
@@ -74,7 +74,7 @@ The \emph{exact} value is found using the function, provided we use the correct 
 To find this, just set $2x-1 = 1.2$.
 \end{hint}
 
-Thus, the \emph{exact} answer to 6 decimal places is $\sqrt{1.2} = \answer[tolerance= .000001]{1.095445}$
+The \emph{exact} answer to 6 decimal places is $\sqrt{1.2} = \answer[tolerance= .000001]{1.095445}$
 
 We can use the third degree Taylor polynomial to write down the first and second degree Taylor polynomials.  We can then substitute $x=1.1$ into these to approximate $\sqrt{1.2}$.  In fact:
 


### PR DESCRIPTION
https://ximera.osu.edu/mooculus/approximatingFunctionsWithPolynomials/exercises/exerciseList/approximatingFunctionsWithPolynomials/exercises/computeTaylorPoly1

Changed: 
Thus, the exact answer to 6 decimal places 
to
The exact answer to 6 decimal places
Since thus here is misleading. This is just putting it in the calculator and does not come as a consequence of the approximations before it.