### PR TITLE
Update computeTaylorPoly2.tex

### DIFF
--- a/approximatingFunctionsWithPolynomials/exercises/computeTaylorPoly2.tex
+++ b/approximatingFunctionsWithPolynomials/exercises/computeTaylorPoly2.tex
@@ -76,7 +76,7 @@ The \emph{exact} value is found using the function, provided we use the correct 
 To find this, just set $5-2x = 2.2$.
 \end{hint}
 
-Thus, the \emph{exact} answer to 6 decimal places is $\ln(.6) = \answer[tolerance= .000002]{-.510826}$
+The \emph{exact} answer to 6 decimal places is $\ln(.6) = \answer[tolerance= .000002]{-.510826}$
 
 We can approximate $\ln(5-2x)$ by substituting $x=2.2$ into the Taylor polynomials.  In fact:
 


### PR DESCRIPTION
https://ximera.osu.edu/mooculus/approximatingFunctionsWithPolynomials/exercises/exerciseList/approximatingFunctionsWithPolynomials/exercises/computeTaylorPoly2

Changed:
Thus, the exact answer to 6 decimal places
To
The exact answer to 6 decimal places
Thus is misleading here since they just have to put it in the calculator and it does not follow from previous approximations.