### PR TITLE
Update derivative1.tex

### DIFF
--- a/calculusAndTaylorSeries/exercises/derivative1.tex
+++ b/calculusAndTaylorSeries/exercises/derivative1.tex
@@ -16,7 +16,7 @@ Suppose that the Taylor series for a certain function $f(x)$ is given by $f(x) =
 Find the Taylor series for $f''(x)$ centered at $x=0$.
 
 \[
-f''(x) = \sum_{k=0}^{\infty} \answer{\frac{3(2k+3)(2k+2)}{k!}} \cdot x^{\answer{2k+1}}
+f''(x) = \sum_{k=2}^{\infty} \answer{\frac{3(2k+3)(2k+2)}{k!}} \cdot x^{\answer{2k+1}}
 \]
 
 


### PR DESCRIPTION
https://ximera.osu.edu/mooculus/calculusAndTaylorSeries/exercises/exerciseList/calculusAndTaylorSeries/exercises/derivative1

Made the sum for f'' to start from k=2 not k=0. Each time a derivative is taken the index go up by one. This is the notation most books use to be perfect in the answer even though the first term does not matter in derivative.