### PR TITLE
Update partialFractionDecomposition.tex

### DIFF
--- a/review/refreshIntegrationTechniques/partialFractionDecomposition.tex
+++ b/review/refreshIntegrationTechniques/partialFractionDecomposition.tex
@@ -83,7 +83,7 @@ Compute $\int \frac{2x^2-4x+8}{x^3+4x} \d x$.
 \[
 \int \frac{2x^2-4x+8}{x^3+4x} \d x = \answer{2 \ln|x|-2\arctan\left(\frac{x}{2}\right)+C}
 \]
-(Use $C$ for the constant of integration)
+(Use $C$ for the constant of integration and $arctan(x)$ instead of $tan^(-1)(x)$)
 \end{exercise}
 
 \end{document}


### PR DESCRIPTION
https://ximera.osu.edu/mooculus/review/refreshIntegrationTechniques/exerciseList/review/refreshIntegrationTechniques/partialFractionDecomposition

At the end in parenthesis reminded them to use arctan instead of tan^(-1) since it does not take tan^(-1).