### PR TITLE
Update trigSub1Guided.tex

### DIFF
--- a/trigonometricSubstitution/exercises/trigSub1Guided.tex
+++ b/trigonometricSubstitution/exercises/trigSub1Guided.tex
@@ -107,7 +107,7 @@ We can now write the antiderivatives of the original function in terms of $x$.
 \[
 \int \frac{1}{ (1+x^2)^2} \d x= \answer{ \frac{1}{2}\arctan(x) + \frac{x}{2(1+x^{2})} + C }
 \]
-(Use $C$ for the constant of integration)
+(Use $C$ for the constant of integration and $arctan(x)$ instead of $tan^-1 (x)$)
 
 \end{exercise}
 


### PR DESCRIPTION
https://ximera.osu.edu/mooculus/trigonometricSubstitution/exercises/exerciseList/trigonometricSubstitution/exercises/trigSub1Guided

Changed the parenthesis to:
(Use $C$ for the constant of integration and $arctan(x)$ instead of $tan^-1 (x)$) To remind them to use arctan instead of tan^(-1).