### PR TITLE
Update piecewiseLimits2.tex

### DIFF
--- a/indeterminateForms/exercises/piecewiseLimits2.tex
+++ b/indeterminateForms/exercises/piecewiseLimits2.tex
@@ -23,9 +23,7 @@ Otherwise write DNE.
 \lim_{x \to 2} g(x) = \answer{9}
 \]
 \end{prompt}
-\begin{hint}
-	Note that, close to $x=2$, the rule for $g(x)$ is $x^3+1$.
-\end{hint}
+
 
 \end{exercise}
 \end{document}


### PR DESCRIPTION
https://ximera.osu.edu/mooculus/indeterminateForms/exercises/exerciseList/indeterminateForms/exercises/piecewiseLimits2

Took out the hint:
Note that, close to $x=2$, the rule for $g(x)$ is $x^3+1$. No hint is needed here. This is an easy piecewise function question.