### PR TITLE
Update piecewiseLimits4.tex

### DIFF
--- a/indeterminateForms/exercises/piecewiseLimits4.tex
+++ b/indeterminateForms/exercises/piecewiseLimits4.tex
@@ -18,7 +18,7 @@ does, give its value.  Otherwise write DNE.
 \] 
 
 \begin{hint}
-  Close to $x=-4$, $S(x)=\frac{-x}{x}$.
+ Write the absolute value as a piecewise function. 
 \end{hint}
 \begin{exercise}
 Let $S(x) = \frac{|x|}{x}$.  Does the limit exist?  If it


### PR DESCRIPTION
https://ximera.osu.edu/mooculus/indeterminateForms/exercises/exerciseList/indeterminateForms/exercises/piecewiseLimits4

Changed the hint from:
Close to $x=-4$, $S(x)=\frac{-x}{x}$.

To:
 Write the absolute value as a piecewise function. 
Since -x/x can be misleading. I think for problems that involve for example |x-4| they should get in the habit of writing the piecewise definition of absolute value first.