### PR TITLE
Update secantLineTangentLine1.tex

### DIFF
--- a/definitionOfTheDerivative/exercises/secantLineTangentLine1.tex
+++ b/definitionOfTheDerivative/exercises/secantLineTangentLine1.tex
@@ -95,7 +95,7 @@ The graph of $s(t)$ is given below.
 
 Assume that $P$ and $A$ are points on the graph of $s(t)$.  Then
 \[
-P = \left(1,\answer{-1}\right) \text{ and } A = \left(t,\answer{t^2-2}\right).
+P = \left(1,\answer{-1}\right) \text{ and in terms of t } A = \left(t,\answer{t^2-2}\right) 
 \]
 
 \begin{exercise}


### PR DESCRIPTION
https://ximera.osu.edu/mooculus/definitionOfTheDerivative/exercises/exerciseList/definitionOfTheDerivative/exercises/secantLineTangentLine1

Added:
\text{ and in terms of t }
in terms of t before A because it is not clear if one should put s(t) or the actual expression for s(t) so I tried to make it a little more clear.