### PR TITLE
Update 14_Q4-1151_ex_1.tex

### DIFF
--- a/higherOrderDerivativesAndGraphs/exercises/14_Q4-1151_ex_1.tex
+++ b/higherOrderDerivativesAndGraphs/exercises/14_Q4-1151_ex_1.tex
@@ -16,9 +16,6 @@ a(t)&=\answer{-8}
 \end{align*}
 \item With what speed will the stone strike the ground? 
 \begin{hint}
-Find the time, $t_{1}$, when the stone strikes the ground.
-\end{hint}
-\begin{hint}
 Find the time, $t_{1}$, when the stone strikes the ground, by solving the equation
 \[
 s(t)=0
@@ -29,7 +26,9 @@ and evaluate  $v(t_{1})$.
 ANSWER: The stone will strike the ground with the speed
 \[\answer{68}\unit{ft/s}\] %% interpreted as speed = |velocity|
 \end{enumerate}
-
+\begin{hint}
+Note that here we want speed not velocity. 
+\end{hint}
 
 
 


### PR DESCRIPTION
https://ximera.osu.edu/mooculus/higherOrderDerivativesAndGraphs/exercises/exerciseList/higherOrderDerivativesAndGraphs/exercises/14_Q4-1151_ex_1

Took out the first hint in:
\begin{hint}
Find the time, $t_{1}$, when the stone strikes the ground. \end{hint}
\begin{hint}
Find the time, $t_{1}$, when the stone strikes the ground, by solving the equation \[
s(t)=0
\]
and evaluate  $v(t_{1})$.
It was repetitive. Also put a hint:
Note that here we want speed not velocity 
so they note that it is +68 not -68.