### PR TITLE
Update inversesTrig6.tex

### DIFF
--- a/derivativesOfInverseFunctions/exercises/inversesTrig6.tex
+++ b/derivativesOfInverseFunctions/exercises/inversesTrig6.tex
@@ -14,9 +14,10 @@
 \begin{exercise}
 
 \[
-\frac{d}{dx} \frac{x}{\sin^{-1}(x)} \begin{prompt}= \answer{\frac{\arcsin(x) - \frac{x}{\sqrt{1-x^2}}}{\arcsin(x)^2}}
+\frac{d}{dx} \frac{x}{\arcsin(x)} \begin{prompt}= \answer{\frac{\arcsin(x) - \frac{x}{\sqrt{1-x^2}}}{\arcsin(x)^2}}
 \end{prompt}
 \]
+(Give inverse trig functions as arcfunction not function^(-1). So $\arctan(x)$ not $\tan^(-1)(x)$)
 
 
 \end{exercise}


### PR DESCRIPTION
https://ximera.osu.edu/mooculus/derivativesOfInverseFunctions/exercises/exerciseList/derivativesOfInverseFunctions/exercises/inversesTrig6

The question uses sin^(-1) but the answer has to be put in as arcsin so I changed the question to arcsin and gave this after it: (Give inverse trig functions as arcfunction not function^(-1). So $\arctan(x)$ not $\tan^(-1)(x)$)