### PR TITLE
Update q14434v1.tex

### DIFF
--- a/antiderivatives/exercises/q14434v1.tex
+++ b/antiderivatives/exercises/q14434v1.tex
@@ -19,11 +19,7 @@ Apply the Sum Rule for antiderivatives.
 Apply the Constant Multiple Rule for antiderivatives.
 \[\int \left(6e^{3r} +12r^3 -5\right)\; dr=\int 6e^{3r}\; dr +\int12r^3\; dr+ \int(-5)\; dr=6\int e^{3r}\; dr +12\int r^3\; dr-5 \int\; dr\]
 \end{hint}
-\begin{hint}
-Guess an antiderivative.
-\[\int e^{3r}\; dr \approx e^{3r}+C \]
-Then differentiate it, and multiply by a factor, if needed.
-\end{hint}
+
 \begin{multipleChoice}
 \choice{$18e^{3r}+36r^2$}
 \choice{$3e^{3r}+4r^4-5r+C$}


### PR DESCRIPTION
https://ximera.osu.edu/mooculus/antiderivatives/exercises/exerciseList/antiderivatives/exercises/q14434v1

I think the hint is too lengthy. Took out:
Guess an antiderivative.
\[\int e^{3r}\; dr \approx e^{3r}+C \]
Then differentiate it, and multiply by a factor, if needed.

It makes it more complicated. 