### PR TITLE
Update positionFromVelocity3.tex

### DIFF
--- a/antiderivatives/exercises/positionFromVelocity3.tex
+++ b/antiderivatives/exercises/positionFromVelocity3.tex
@@ -21,7 +21,7 @@ t-2 & 0\leq t\leq4\\
 2\cos\left(\frac{\pi t}{2}\right) & 4<t\leq8
 \end{cases}.
 \]
-(a) Find $s(t)$, the position of the object at a time $t$, for $0\leq t\leq8$.
+Find $s(t)$, the position of the object at a time $t$, for $0\leq t\leq8$.
 \begin{hint}
 Solve the IVP:
 \[
@@ -61,12 +61,6 @@ Therefore, using the expression for $s(t)$ for $t$ in $[0,4]$, we get that
 
  $s(4)= \lim_{t\to 4^{-}}s(t)=
 \frac{1}{2}(16)-2(4)=0$
-\end{hint}
-\begin{hint}
-For $0\leq t\leq4$:
-\[
-s(t) =\answer{\frac{1}{2}}t^2-\answer{2}t+\answer{0}
-\]
 \end{hint}
 \begin{hint}
 Now we have to solve the IVP for $4\leq t\leq8$:


### PR DESCRIPTION
https://ximera.osu.edu/mooculus/antiderivatives/exercises/exerciseList/antiderivatives/exercises/positionFromVelocity3

In the hints the solution for 0<t<4 was given twice so took the second one that was in the middle of the calculation of the other interval out.