### PR TITLE
Update definiteIntegral4.tex

### DIFF
--- a/definiteIntegral/exercises/definiteIntegral4.tex
+++ b/definiteIntegral/exercises/definiteIntegral4.tex
@@ -21,9 +21,8 @@
 
 Evaluate the following integrals.  Use geometry and properties of the definite integral.
 \begin{hint}
-Use  geometry, properties of definite integrals and/or symmetry.
-
-Recall: $\int_{-a}^a (any \hspace{0.05in}odd\hspace{0.05in} function)(x) \d x =0$!
+Recall: $\int_{-a}^a (any \hspace{0.05in}odd\hspace{0.05in} function)(x) \d x =0$!\\
+Use technology like Desmos.com/calculator to graph then use geometry, properties of definite integrals and/or symmetry.
 \end{hint}
 \begin{align*}
 \int_{-2}^2 \cos(x)\sin(x) \d x &= \answer{0}\\


### PR DESCRIPTION
https://ximera.osu.edu/mooculus/definiteIntegral/exercises/exerciseList/definiteIntegral/exercises/definiteIntegral4

Since they can't do these by hand yet then have to graph them so made the hint change to: Recall: $\int_{-a}^a (any \hspace{0.05in}odd\hspace{0.05in} function)(x) \d x =0$!\\ Use technology like Desmos.com/calculator to graph then use geometry, properties of definite integrals and/or symmetry.