### PR TITLE
Update antiderivativeBasic2.tex

### DIFF
--- a/definiteIntegral/exercises/antiderivativeBasic2.tex
+++ b/definiteIntegral/exercises/antiderivativeBasic2.tex
@@ -17,10 +17,10 @@
 Which of the following are antiderivatives of $\frac{1}{2x}$ with respect to $x$?  Check all that apply.
 
 \begin{selectAll}
-	\choice[correct]{$\frac{\ln(x)}{2}+2$}
+	\choice[correct]{$\frac{\ln|x|}{2}+2$}
 	\choice{$\frac{-1}{2x^2}+3$}
-	\choice[correct]{$\frac{\ln(4x)}{2}$}
-	\choice{$\frac{1}{2}(\ln(x+3)-3)$}
+	\choice[correct]{$\frac{\ln|4x|}{2}$}
+	\choice{$\frac{1}{2}(\ln|x+3|-3)$}
 \end{selectAll}
 
 Does this violate our result about antiderivatives being constant shifts of each other?  If not, why not?


### PR DESCRIPTION
https://ximera.osu.edu/mooculus/definiteIntegral/exercises/exerciseList/definiteIntegral/exercises/antiderivativeBasic2

We keep asking ln to be given with absolute values so to be consistent I changed all lns in the choices to those with absolute values.