### PR TITLE
Update antiderivativeTrueFalse6.tex

### DIFF
--- a/definiteIntegral/exercises/antiderivativeTrueFalse6.tex
+++ b/definiteIntegral/exercises/antiderivativeTrueFalse6.tex
@@ -17,6 +17,9 @@
 
 $\int e^x f(x) \d x= e^x \int f(x) \d x$
 \begin{hint}
+We can't take a function that depends on $x$ out of the integral. \\
+Also if the statement was true then we should have equality for the equation for any function. \\
+
 Take a simple function $f(x)=1$. 
 
 Then we have


### PR DESCRIPTION
https://ximera.osu.edu/mooculus/definiteIntegral/exercises/exerciseList/definiteIntegral/exercises/antiderivativeTrueFalse6

Added to the hint that we can't take a function that depends on x out of the integral, because I think that is the bigger point here. Then for the example I connected it by a few words.