### PR TITLE
Update 06_01_ex_38.tex

### DIFF
--- a/substitution/exercises/06_01_ex_38.tex
+++ b/substitution/exercises/06_01_ex_38.tex
@@ -20,14 +20,13 @@ Find the indefinite integral of $\frac{\ln(x^3)}{x}$ with respect to $x$.
 \int \frac{\ln(x^3)}{x}\d x=\answer{\frac{1}{6}(\ln(x^3))^2}+C
 \]
 \begin{hint}
-First simplify!
+Using log properties, write the integral as $\int 3\frac{\ln(x)}{x}\d x$ then use $u=\ln(x)$.
 \end{hint}
 \begin{hint}
-Recall: $\ln(x^3)=3\ln(x)$ !
+Another way: let $u=ln(x^3)$ at the beginning without using log properties. 
 \end{hint}
 \begin{hint}
-Write the integral as $\int 3\frac{\ln(x)}{x}\d x$ and use $u=\ln(x)$.
+Try solving it both ways and verify that both answers are the same. 
 \end{hint}
-
 \end{exercise}
 \end{document}


### PR DESCRIPTION
https://ximera.osu.edu/mooculus/substitution/exercises/exerciseList/substitution/exercises/06_01_ex_38

If one puts u to be (ln(x^3)) then it works as well and it is good for them to try both ways and see different ways to put u and get the same answer.