### PR TITLE
Update meanValueStandard1.tex

### DIFF
--- a/meanValueTheorem/exercises/meanValueStandard1.tex
+++ b/meanValueTheorem/exercises/meanValueStandard1.tex
@@ -9,23 +9,7 @@
 
 What point $c$ satisfies the conclusion of the Mean Value Theorem for the function $f(x) = x^2 +x$ on the interval
 $[2,6]$?
-\begin{hint}
-You have to find a point $c$ in $(2,6)$ such that $f'(c)=\frac{f(6)-f(2)}{6-2}$.
-\end{hint}
-\begin{hint}
-First, compute the average rate of change of $f$ over the interval $[2,6]$,
 
-$\frac{f(6)-f(2)}{6-2}=\answer{9}$.
-\end{hint}
-\begin{hint}
-Next, we have to compute $f'(x)$.
-
-$f'(x)=\answer{2x+1}$.
-\end{hint}
-\begin{hint}
-And last, we have to solve the equation
-$f'(c)=\answer{9}$.
-\end{hint}
 \begin{prompt}
 	$$c = \answer{4}$$
 \end{prompt}


### PR DESCRIPTION
https://ximera.osu.edu/mooculus/meanValueTheorem/exercises/exerciseList/meanValueTheorem/exercises/meanValueStandard1

I took out the hint. This is a simple Mean Value theorem and no hint is needed. Also the hint does not appear well even after I tried to go back a slide and come back:
![image](https://github.com/mooculus/calculus/assets/156558883/f1beaf79-a930-4205-8d74-496a35e6c945)
