### PR TITLE
Update meanValueNonstandard1.tex

### DIFF
--- a/meanValueTheorem/exercises/meanValueNonstandard1.tex
+++ b/meanValueTheorem/exercises/meanValueNonstandard1.tex
@@ -37,15 +37,7 @@ f'(x) =2A\answer{x}+B
 \end{hint}
 
 \begin{hint}
-Then, we solve the equation
-
-\[
-f'(c) =A\left(\answer{b+a}\right)+B
-\]
-\end{hint}
-
-\begin{hint}
-In the equation above we replace $f'(c)$ with $2A\answer{c}+B $. Now, we solve for $c$:
+Then, we solve the equation below for $c$
 
 \[
 2A(\answer{c})+B =A\left(\answer{b+a}\right)+B


### PR DESCRIPTION
https://ximera.osu.edu/mooculus/meanValueTheorem/exercises/exerciseList/meanValueTheorem/exercises/meanValueNonstandard1?

I shortened the hint and made it more direct.
![image](https://github.com/mooculus/calculus/assets/156558883/ab8bbabe-b7f7-4ea0-b58c-04c639bb14af)
Having f’( c ) after f’(x) makes one think it is f’ (c) = A (2c) +B but they meant it to be based on f’(c) on the line before f’(x). 