### PR TITLE
Update LinearApproximations7.tex

### DIFF
--- a/linearApproximation/exercises/LinearApproximations7.tex
+++ b/linearApproximation/exercises/LinearApproximations7.tex
@@ -28,9 +28,9 @@ We can express the relationship between a small change in $t$ and the correspond
 \d{N} = \frac{\answer{2000000}e^{-0.1t}}{\left(1+100e^{-0.1t}\right)^2}\d{t}.
 \]
 
-Assuming that 45 days have passed since the outbreak started, we use the above formula to estimate the number of people (rounded to the nearest 1 person) that will fall sick in the next day. That number is approximately $\answer{4986}$.
+After 45 days since the outbreak started, we use the above formula to estimate the number of people (rounded to the nearest 1 person) that will fall sick on the next day. That number is approximately $\answer{4986}$.
 
-Assuming that 100 days have passed since the outbreak started, we use the above formula to estimate the number of people (rounded to the nearest 1 person) that will fall sick in the next day. That number is approximately $\answer{90}$.
+After 100 days since the outbreak started, we use the above formula to estimate the number of people (rounded to the nearest 1 person) that will fall sick on the next day. That number is approximately $\answer{90}$.
 
 \end{exercise}
 \end{document}


### PR DESCRIPTION
https://ximera.osu.edu/mooculus/linearApproximation/exercises/exerciseList/linearApproximation/exercises/LinearApproximations7

Changed the wording of the questions. On the next day after 45 days have passed, made me think t should be 46 first but t is the number of days after the outbreak. So after 45 days makes it more clear.