### PR TITLE
Update singVarCalcOptimization13.tex

### DIFF
--- a/optimization/exercises/singVarCalcOptimization13.tex
+++ b/optimization/exercises/singVarCalcOptimization13.tex
@@ -75,7 +75,7 @@
                                 
                                 $A\left(\frac{10}{2+\pi}\right)=\frac{50\pi}{(2+\pi)^2}$
                                 
-                                $A\left(\frac{\answer{10}}{4+\pi}\right)=\frac{\answer{50}}{4+\pi}\approx 7$
+                                $A\left(\frac{\answer{10}}{4+\pi}\right)=\frac{\answer{200+350\pi}}{(4+\pi)^2}\approx 7$
                                 
                                 This seems complicated. It is better to argue that the derivative 
                                 


### PR DESCRIPTION
https://ximera.osu.edu/mooculus/optimization/exercises/exerciseList/optimization/exercises/singVarCalcOptimization13

The answer for A(10/(4+pi)) was not correct:
![image](https://github.com/mooculus/calculus/assets/156558883/0de27a44-015c-4ec6-8c68-c6ab0a6ce3df)
For A(10/(4+pi)) they have the answer as:
![image](https://github.com/mooculus/calculus/assets/156558883/c13fe555-b75a-4f53-8a7a-e28a3c07e5d7)
but it should be (200 + 350pi)/(4+pi)^2 so I changed it and matched it to the setting of A(10/(2+pi)) with (2+pi)^2 in the bottom. 