### PR TITLE
Update singVarCalcOptimization16.tex

### DIFF
--- a/optimization/exercises/singVarCalcOptimization16.tex
+++ b/optimization/exercises/singVarCalcOptimization16.tex
@@ -88,8 +88,8 @@ A\left(\sqrt{\frac{\answer{3}}{2}}\right)=4\sqrt{\frac{\answer{3}}{2}}\sqrt{5-  
 \end{hint}
   \begin{prompt}
   \begin{align*}
-  \text{base}&= \answer{\sqrt{6}}\\
-  \text{height} &= \answer{\sqrt{10}}
+  \text{length}&= \answer{\sqrt{6}}\\
+  \text{width} &= \answer{\sqrt{10}}
   \end{align*}
   \end{prompt}
 \end{exercise}


### PR DESCRIPTION
https://ximera.osu.edu/mooculus/optimization/exercises/exerciseList/optimization/exercises/singVarCalcOptimization16


For rectangle we should use length and width. It was using base and height when asking for dimensions.