### PR TITLE
Update digInAppliedRelatedRates.tex

### DIFF
--- a/appliedRelatedRates/digInAppliedRelatedRates.tex
+++ b/appliedRelatedRates/digInAppliedRelatedRates.tex
@@ -491,7 +491,7 @@ We \textbf{solve} for $\frac{d\theta}{dt}$, when $p=4$, and get that
   It is night. Someone who is $6$ feet tall is walking away from a
   street light at a rate of $3$ feet per second.  The street light is
   $15$ feet tall.  The person casts a shadow on the ground in front of
-  them. How fast is the length of the shadow growing when the person
+  him/her. How fast is the length of the shadow growing when the person
   is $7$ feet from the street light?
 
   \begin{explanation}


### PR DESCRIPTION
Fixed a typo. In the example it says someone then refers to him/her as them.
Pg. 165:
 
![image](https://github.com/mooculus/calculus/assets/156558883/813cf87c-60ff-4ba1-8eea-776f0b2d8597)

Him/her not them. 
