### PR TITLE
Update relatedRatesApplied3.tex

### DIFF
--- a/appliedRelatedRates/exercises/relatedRatesApplied3.tex
+++ b/appliedRelatedRates/exercises/relatedRatesApplied3.tex
@@ -10,15 +10,18 @@
 
 \begin{exercise}
   Two row boats start at the same location, and start traveling apart
-  along straight lines which meet at an angle of $\frac{\pi}{3}$.
+  along straight lines at an angle of $\frac{\pi}{3}$.
 
 
   Boat $A$ is traveling at a rate of $5$ miles per hour directly east,
   and boat $B$ is traveling at a rate of $10$ miles per hour going
-  both north and east.
+  northeast.
 
   How fast is the distance between the rowboats increasing $3$ hours
   into the journey?
+  \begin{hint}
+  Draw a 30/60/90 triangle and note that one boat is going twice as fast as the other.
+  \end{hint}
 
 \begin{prompt}
   The rowboats are diverging from each other at a rate of


### PR DESCRIPTION
https://ximera.osu.edu/mooculus/appliedRelatedRates/exercises/exerciseList/appliedRelatedRates/exercises/relatedRatesApplied3

changed some of the wording:
changed which meet at an angle" to "that form at an angle"
changed both north and east to northeast
 and added the hint:
Draw a 30/60/90 triangle and note that one boat is going twice as fast as the other. Since then we can use 30/60/90 triangle, otherwise it might be this triangle:
![image](https://github.com/mooculus/calculus/assets/156558883/8df0e66d-9d08-4b2a-89e3-0c862b1121b3)

that is not a right triangle. Comparing it to 30/60/90 we can see that this gives a right triangle. 