### PR TITLE
Update applicationsOfIntegrals10.tex

### DIFF
--- a/applicationsOfIntegrals/exercises/applicationsOfIntegrals10.tex
+++ b/applicationsOfIntegrals/exercises/applicationsOfIntegrals10.tex
@@ -19,9 +19,9 @@ P'(t) = 60e^{-0.2t}
 \]
 where $P'(t)$ is measured in cells per hour.
 
-The  number of cells after 2 hours (rounded to the nearest cell) is
+The  number of cells after 2 hours is
 \[
-P(2) = \answer{299}
+P(2) = \answer{299} \text{round to a whole number}
 \]
 
 For $t\geq0$ the number of cells is given by


### PR DESCRIPTION
https://ximera.osu.edu/mooculus/applicationsOfIntegrals/exercises/exerciseList/applicationsOfIntegrals/exercises/applicationsOfIntegrals10

It is easy to miss that the answer has to be rounded:
![image](https://github.com/mooculus/calculus/assets/156558883/f05f8780-17b4-4e53-9129-efe27d0d50da)

It says to the nearest cell which sounds vague. I put a hint beside the box saying round to the nearest whole number. The answer comes out to be:
![image](https://github.com/mooculus/calculus/assets/156558883/c88a1172-07f0-4587-8fd7-b845cb92c851)
and it does not take the unsimplified version. 